### PR TITLE
fix: a single `\n` is added when using transform function API

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function getTransformStream() {
   return new Transform({
     objectMode: true,
     transform(chunk, enc, cb) {
-      const line = chunk.toString();
+      const line = chunk.toString().trim();
 
       /* istanbul ignore if */
       if (line === undefined) return cb();
@@ -73,7 +73,7 @@ function getTransformStream() {
         return cb(null, stringifyLogLevel(data || JSON.parse(line)));
       }
 
-      cb(null, chunk.toString() + "\n");
+      cb(null, line + "\n");
     },
   });
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,11 +1,43 @@
+const Stream = require("stream");
+
 const test = require("tap").test;
+const pino = require("pino");
+const { getTransformStream } = require("..");
 
 test("API", (t) => {
-  t.test("getTransformStream", (t) => {
-    const { getTransformStream } = require("..");
+  t.test("getTransformStream export", (t) => {
     t.isA(getTransformStream, Function);
     t.end();
   });
+
+  t.test(
+    "ONly a single \\n is added to the end log lines when LOG_FORMAT is set to 'json' (https://github.com/probot/probot/issues/1334)",
+    (t) => {
+      process.env.LOG_FORMAT = "json";
+
+      const streamLogsToOutput = new Stream.Writable({ objectMode: true });
+      const output = [];
+      streamLogsToOutput._write = (line, encoding, done) => {
+        output.push(line);
+        done();
+      };
+
+      const transform = getTransformStream();
+      transform.pipe(streamLogsToOutput);
+      const log = pino({}, transform);
+
+      log.info("test");
+
+      t.equal(
+        output.join(""),
+        output.join("").trim() + "\n",
+        'No "\\n" is added to end of line'
+      );
+
+      delete process.env.LOG_FORMAT;
+      t.end();
+    }
+  );
 
   t.end();
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,7 @@ test("API", (t) => {
   });
 
   t.test(
-    "ONly a single \\n is added to the end log lines when LOG_FORMAT is set to 'json' (https://github.com/probot/probot/issues/1334)",
+    "A single \\n is added to the end log lines when LOG_FORMAT is set to 'json' (https://github.com/probot/probot/issues/1334)",
     (t) => {
       process.env.LOG_FORMAT = "json";
 


### PR DESCRIPTION
closes https://github.com/probot/probot/issues/1334