### PR TITLE
fix(sentry): pass sentry error properties with depth of 10 (instead of default 2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const { Transform } = require("readable-stream");
 
 const prettyFactory = require("pino-pretty");
 const Sentry = require("@sentry/node");
+const { ExtraErrorData } = require("@sentry/integrations");
 
 const LEVEL_MAP = {
   "10": "trace",
@@ -22,6 +23,7 @@ function getTransformStream() {
   if (sentryEnabled) {
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
+      integrations: [new ExtraErrorData({ depth: 10 })],
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -573,6 +573,33 @@
         "tslib": "^1.9.3"
       }
     },
+    "@sentry/integrations": {
+      "version": "5.22.3",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.22.3.tgz",
+      "integrity": "sha512-Fx6h8DTDvUpEOymx8Wi49LBdVcNYHwaI6NqApm1qVU9qn/I50Q29KWoZTCGBjBwmkJud+DOAHWYWoU2qRrIvcQ==",
+      "requires": {
+        "@sentry/types": "5.22.3",
+        "@sentry/utils": "5.22.3",
+        "localforage": "1.8.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "5.22.3",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.22.3.tgz",
+          "integrity": "sha512-cv+VWK0YFgCVDvD1/HrrBWOWYG3MLuCUJRBTkV/Opdy7nkdNjhCAJQrEyMM9zX0sac8FKWKOHT0sykNh8KgmYw=="
+        },
+        "@sentry/utils": {
+          "version": "5.22.3",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.22.3.tgz",
+          "integrity": "sha512-AHNryXMBvIkIE+GQxTlmhBXD0Ksh+5w1SwM5qi6AttH+1qjWLvV6WB4+4pvVvEoS8t5F+WaVUZPQLmCCWp6zKw==",
+          "requires": {
+            "@sentry/types": "5.22.3",
+            "tslib": "^1.9.3"
+          }
+        }
+      }
+    },
     "@sentry/minimal": {
       "version": "5.21.1",
       "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.21.1.tgz",
@@ -2198,6 +2225,11 @@
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -2621,6 +2653,14 @@
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
       "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -2645,6 +2685,14 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
+      }
+    },
+    "localforage": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.8.1.tgz",
+      "integrity": "sha512-azSSJJfc7h4bVpi0PGi+SmLQKJl2/8NErI+LhJsrORNikMZnhaQ7rv9fHj+ofwgSHrKRlsDCL/639a6nECIKuQ==",
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "tap": "^14.10.8"
   },
   "dependencies": {
+    "@sentry/integrations": "^5.22.3",
     "@sentry/node": "^5.21.1",
     "pino-pretty": "^4.1.0",
     "pump": "^3.0.0",


### PR DESCRIPTION
This should prevent extra data set on errors from being hidden when they are more than two properties deep, like this

<img width="875" alt="image" src="https://user-images.githubusercontent.com/39992/92334589-59028080-f044-11ea-9105-bde12b7479f3.png">
