### PR TITLE
fix(getTransformStream): compare opts.logLevelInString as boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const LEVEL_MAP = {
 function getTransformStream(options = {}) {
   const formattingEnabled = options.logFormat !== "json";
 
-  const levelAsString = options.logLevelInString === "true";
+  const levelAsString = options.logLevelInString;
   const sentryEnabled = !!options.sentryDsn;
 
   if (sentryEnabled) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -143,6 +143,7 @@ test("API", (t) => {
 
       const transform = getTransformStream({
         logFormat: "json",
+        logLevelInString: true,
       });
       transform.pipe(streamLogsToOutput);
       const log = pino({}, transform);
@@ -154,6 +155,8 @@ test("API", (t) => {
         output.join("").trim() + "\n",
         'No "\\n" is added to end of line'
       );
+
+      t.equal(JSON.parse(output).level, "info");
 
       t.end();
     }


### PR DESCRIPTION
`options.logLevelInString` is a `boolean`, so comparing with a `string` will always result in `levelAsString` to be `false`.

closes https://github.com/probot/probot/issues/1541