### PR TITLE
chore: remove readable-stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = { getTransformStream };
 
-const { Transform } = require("readable-stream");
+const { Transform } = require("node:stream");
 
 const prettyFactory = require("pino-pretty");
 const Sentry = require("@sentry/node");

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@sentry/node": "^6.0.0",
         "pino-pretty": "^6.0.0",
         "pump": "^3.0.0",
-        "readable-stream": "^3.6.0",
         "split2": "^4.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@sentry/node": "^6.0.0",
     "pino-pretty": "^6.0.0",
     "pump": "^3.0.0",
-    "readable-stream": "^3.6.0",
     "split2": "^4.0.0"
   },
   "release": {


### PR DESCRIPTION
We can use the native stream package of node. No need to use the readable-stream one. 