### PR TITLE
test: include latest Node.js versions in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ jobs:
           - 10
           - 12
           - 14
+          - 16
+          - 18
+          - 20
+          - 22
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node_version }}


### PR DESCRIPTION
Looks like the test workflow in this repo hasn't been updated in a while to use the latest Node.js versions, so adding them to the test matrix here.