### PR TITLE
feat: upgrade @sentry/node to v7

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,8 +76,7 @@ function getTransformStream(options = {}) {
       }
 
       Sentry.withScope(function (scope) {
-        const sentryLevelName =
-          data.level === 50 ? Sentry.Severity.Error : Sentry.Severity.Fatal;
+        const sentryLevelName = data.level === 50 ? "error" : "fatal";
         scope.setLevel(sentryLevelName);
 
         for (const extra of ["event", "headers", "request", "status"]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -275,65 +275,59 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@sentry-internal/tracing": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+      "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
+      "requires": {
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
+      }
+    },
     "@sentry/core": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
-      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+      "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
       "requires": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       }
     },
-    "@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
+    "@sentry/integrations": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+      "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
       "requires": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
-      "requires": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2",
+        "localforage": "^1.8.1"
       }
     },
     "@sentry/node": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
-      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.119.2.tgz",
+      "integrity": "sha512-TPNnqxh+Myooe4jTyRiXrzrM2SH08R4+nrmBls4T7lKp2E5R/3mDSe/YTn5rRcUt1k1hPx1NgO/taG0DoS5cXA==",
       "requires": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       }
     },
     "@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg=="
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+      "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg=="
     },
     "@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+      "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
       "requires": {
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.119.2"
       }
     },
     "@types/pino": {
@@ -343,14 +337,6 @@
       "dev": true,
       "requires": {
         "pino": "*"
-      }
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "requires": {
-        "debug": "4"
       }
     },
     "aggregate-error": {
@@ -596,11 +582,6 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
     },
-    "cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -621,6 +602,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.3"
       }
@@ -856,14 +838,10 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -1130,6 +1108,22 @@
         "trivial-deferred": "^1.0.1"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "requires": {
+        "lie": "3.1.1"
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -1161,11 +1155,6 @@
           "dev": true
         }
       }
-    },
-    "lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -1208,7 +1197,8 @@
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node-preload": {
       "version": "0.2.1",
@@ -1637,6 +1627,14 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1646,14 +1644,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -1720,6 +1710,7 @@
       "dependencies": {
         "@ampproject/remapping": {
           "version": "2.2.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@jridgewell/gen-mapping": "^0.3.0",
@@ -1728,6 +1719,7 @@
         },
         "@babel/code-frame": {
           "version": "7.23.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/highlight": "^7.23.4",
@@ -1736,10 +1728,12 @@
         },
         "@babel/compat-data": {
           "version": "7.23.5",
+          "bundled": true,
           "dev": true
         },
         "@babel/core": {
           "version": "7.23.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@ampproject/remapping": "^2.2.0",
@@ -1761,6 +1755,7 @@
         },
         "@babel/generator": {
           "version": "7.23.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/types": "^7.23.6",
@@ -1771,6 +1766,7 @@
         },
         "@babel/helper-annotate-as-pure": {
           "version": "7.22.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/types": "^7.22.5"
@@ -1778,6 +1774,7 @@
         },
         "@babel/helper-compilation-targets": {
           "version": "7.23.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/compat-data": "^7.23.5",
@@ -1789,10 +1786,12 @@
         },
         "@babel/helper-environment-visitor": {
           "version": "7.22.20",
+          "bundled": true,
           "dev": true
         },
         "@babel/helper-function-name": {
           "version": "7.23.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/template": "^7.22.15",
@@ -1801,6 +1800,7 @@
         },
         "@babel/helper-hoist-variables": {
           "version": "7.22.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/types": "^7.22.5"
@@ -1808,6 +1808,7 @@
         },
         "@babel/helper-module-imports": {
           "version": "7.22.15",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/types": "^7.22.15"
@@ -1815,6 +1816,7 @@
         },
         "@babel/helper-module-transforms": {
           "version": "7.23.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/helper-environment-visitor": "^7.22.20",
@@ -1826,10 +1828,12 @@
         },
         "@babel/helper-plugin-utils": {
           "version": "7.22.5",
+          "bundled": true,
           "dev": true
         },
         "@babel/helper-simple-access": {
           "version": "7.22.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/types": "^7.22.5"
@@ -1837,6 +1841,7 @@
         },
         "@babel/helper-split-export-declaration": {
           "version": "7.22.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/types": "^7.22.5"
@@ -1844,18 +1849,22 @@
         },
         "@babel/helper-string-parser": {
           "version": "7.23.4",
+          "bundled": true,
           "dev": true
         },
         "@babel/helper-validator-identifier": {
           "version": "7.22.20",
+          "bundled": true,
           "dev": true
         },
         "@babel/helper-validator-option": {
           "version": "7.23.5",
+          "bundled": true,
           "dev": true
         },
         "@babel/helpers": {
           "version": "7.23.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/template": "^7.22.15",
@@ -1865,6 +1874,7 @@
         },
         "@babel/highlight": {
           "version": "7.23.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.22.20",
@@ -1874,10 +1884,12 @@
         },
         "@babel/parser": {
           "version": "7.23.6",
+          "bundled": true,
           "dev": true
         },
         "@babel/plugin-proposal-object-rest-spread": {
           "version": "7.20.7",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/compat-data": "^7.20.5",
@@ -1889,6 +1901,7 @@
         },
         "@babel/plugin-syntax-jsx": {
           "version": "7.23.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.22.5"
@@ -1896,6 +1909,7 @@
         },
         "@babel/plugin-syntax-object-rest-spread": {
           "version": "7.8.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
@@ -1903,6 +1917,7 @@
         },
         "@babel/plugin-transform-destructuring": {
           "version": "7.23.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.22.5"
@@ -1910,6 +1925,7 @@
         },
         "@babel/plugin-transform-parameters": {
           "version": "7.23.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.22.5"
@@ -1917,6 +1933,7 @@
         },
         "@babel/plugin-transform-react-jsx": {
           "version": "7.23.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -1928,6 +1945,7 @@
         },
         "@babel/template": {
           "version": "7.22.15",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.22.13",
@@ -1937,6 +1955,7 @@
         },
         "@babel/traverse": {
           "version": "7.23.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.23.5",
@@ -1953,6 +1972,7 @@
         },
         "@babel/types": {
           "version": "7.23.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.23.4",
@@ -1962,6 +1982,7 @@
         },
         "@isaacs/import-jsx": {
           "version": "4.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@babel/core": "^7.5.5",
@@ -1977,6 +1998,7 @@
         },
         "@jridgewell/gen-mapping": {
           "version": "0.3.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@jridgewell/set-array": "^1.0.1",
@@ -1986,18 +2008,22 @@
         },
         "@jridgewell/resolve-uri": {
           "version": "3.1.1",
+          "bundled": true,
           "dev": true
         },
         "@jridgewell/set-array": {
           "version": "1.1.2",
+          "bundled": true,
           "dev": true
         },
         "@jridgewell/sourcemap-codec": {
           "version": "1.4.15",
+          "bundled": true,
           "dev": true
         },
         "@jridgewell/trace-mapping": {
           "version": "0.3.20",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@jridgewell/resolve-uri": "^3.1.0",
@@ -2006,10 +2032,12 @@
         },
         "@types/prop-types": {
           "version": "15.7.11",
+          "bundled": true,
           "dev": true
         },
         "@types/react": {
           "version": "17.0.73",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@types/prop-types": "*",
@@ -2019,14 +2047,17 @@
         },
         "@types/scheduler": {
           "version": "0.16.8",
+          "bundled": true,
           "dev": true
         },
         "@types/yoga-layout": {
           "version": "1.9.2",
+          "bundled": true,
           "dev": true
         },
         "ansi-escapes": {
           "version": "4.3.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "type-fest": "^0.21.3"
@@ -2034,16 +2065,19 @@
           "dependencies": {
             "type-fest": {
               "version": "0.21.3",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "ansi-regex": {
           "version": "5.0.1",
+          "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -2051,22 +2085,27 @@
         },
         "ansicolors": {
           "version": "0.3.2",
+          "bundled": true,
           "dev": true
         },
         "astral-regex": {
           "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "auto-bind": {
           "version": "4.0.0",
+          "bundled": true,
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -2075,6 +2114,7 @@
         },
         "browserslist": {
           "version": "4.22.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "caniuse-lite": "^1.0.30001565",
@@ -2085,6 +2125,7 @@
         },
         "caller-callsite": {
           "version": "4.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "callsites": "^3.1.0"
@@ -2092,6 +2133,7 @@
         },
         "caller-path": {
           "version": "3.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "caller-callsite": "^4.1.0"
@@ -2099,14 +2141,17 @@
         },
         "callsites": {
           "version": "3.1.0",
+          "bundled": true,
           "dev": true
         },
         "caniuse-lite": {
           "version": "1.0.30001570",
+          "bundled": true,
           "dev": true
         },
         "cardinal": {
           "version": "2.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansicolors": "~0.3.2",
@@ -2115,6 +2160,7 @@
         },
         "chalk": {
           "version": "2.4.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -2124,14 +2170,17 @@
         },
         "ci-info": {
           "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "cli-boxes": {
           "version": "2.2.1",
+          "bundled": true,
           "dev": true
         },
         "cli-cursor": {
           "version": "3.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "restore-cursor": "^3.1.0"
@@ -2139,6 +2188,7 @@
         },
         "cli-truncate": {
           "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "slice-ansi": "^3.0.0",
@@ -2147,6 +2197,7 @@
         },
         "code-excerpt": {
           "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "convert-to-spaces": "^1.0.1"
@@ -2154,6 +2205,7 @@
         },
         "color-convert": {
           "version": "1.9.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -2161,30 +2213,37 @@
         },
         "color-name": {
           "version": "1.1.3",
+          "bundled": true,
           "dev": true
         },
         "commondir": {
           "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
+          "bundled": true,
           "dev": true
         },
         "convert-source-map": {
           "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "convert-to-spaces": {
           "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "csstype": {
           "version": "3.1.3",
+          "bundled": true,
           "dev": true
         },
         "debug": {
           "version": "4.3.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -2192,30 +2251,37 @@
         },
         "electron-to-chromium": {
           "version": "1.4.614",
+          "bundled": true,
           "dev": true
         },
         "emoji-regex": {
           "version": "8.0.0",
+          "bundled": true,
           "dev": true
         },
         "escalade": {
           "version": "3.1.1",
+          "bundled": true,
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
+          "bundled": true,
           "dev": true
         },
         "esprima": {
           "version": "4.0.1",
+          "bundled": true,
           "dev": true
         },
         "events-to-array": {
           "version": "1.1.2",
+          "bundled": true,
           "dev": true
         },
         "find-cache-dir": {
           "version": "3.3.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -2225,6 +2291,7 @@
         },
         "find-up": {
           "version": "4.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
@@ -2233,14 +2300,17 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "gensync": {
           "version": "1.0.0-beta.2",
+          "bundled": true,
           "dev": true
         },
         "glob": {
           "version": "7.2.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2253,18 +2323,22 @@
         },
         "globals": {
           "version": "11.12.0",
+          "bundled": true,
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
+          "bundled": true,
           "dev": true
         },
         "indent-string": {
           "version": "4.0.0",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -2273,10 +2347,12 @@
         },
         "inherits": {
           "version": "2.0.4",
+          "bundled": true,
           "dev": true
         },
         "ink": {
           "version": "3.2.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
@@ -2306,6 +2382,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.3.0",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "color-convert": "^2.0.1"
@@ -2313,6 +2390,7 @@
             },
             "chalk": {
               "version": "4.1.2",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -2321,6 +2399,7 @@
             },
             "color-convert": {
               "version": "2.0.1",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "color-name": "~1.1.4"
@@ -2328,14 +2407,17 @@
             },
             "color-name": {
               "version": "1.1.4",
+              "bundled": true,
               "dev": true
             },
             "has-flag": {
               "version": "4.0.0",
+              "bundled": true,
               "dev": true
             },
             "supports-color": {
               "version": "7.2.0",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "has-flag": "^4.0.0"
@@ -2345,6 +2427,7 @@
         },
         "is-ci": {
           "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ci-info": "^2.0.0"
@@ -2352,22 +2435,27 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
+          "bundled": true,
           "dev": true
         },
         "js-tokens": {
           "version": "4.0.0",
+          "bundled": true,
           "dev": true
         },
         "jsesc": {
           "version": "2.5.2",
+          "bundled": true,
           "dev": true
         },
         "json5": {
           "version": "2.2.3",
+          "bundled": true,
           "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
@@ -2375,10 +2463,12 @@
         },
         "lodash": {
           "version": "4.17.21",
+          "bundled": true,
           "dev": true
         },
         "loose-envify": {
           "version": "1.4.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "js-tokens": "^3.0.0 || ^4.0.0"
@@ -2386,6 +2476,7 @@
         },
         "lru-cache": {
           "version": "5.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "yallist": "^3.0.2"
@@ -2393,6 +2484,7 @@
         },
         "make-dir": {
           "version": "3.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
@@ -2400,10 +2492,12 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
           "version": "3.1.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -2411,6 +2505,7 @@
         },
         "minipass": {
           "version": "3.3.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -2418,24 +2513,29 @@
           "dependencies": {
             "yallist": {
               "version": "4.0.0",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "ms": {
           "version": "2.1.2",
+          "bundled": true,
           "dev": true
         },
         "node-releases": {
           "version": "2.0.14",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
+          "bundled": true,
           "dev": true
         },
         "once": {
           "version": "1.4.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -2443,6 +2543,7 @@
         },
         "onetime": {
           "version": "5.1.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mimic-fn": "^2.1.0"
@@ -2450,6 +2551,7 @@
         },
         "p-limit": {
           "version": "2.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -2457,6 +2559,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
@@ -2464,26 +2567,32 @@
         },
         "p-try": {
           "version": "2.2.0",
+          "bundled": true,
           "dev": true
         },
         "patch-console": {
           "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "path-exists": {
           "version": "4.0.0",
+          "bundled": true,
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "picocolors": {
           "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "pkg-dir": {
           "version": "4.2.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "^4.0.0"
@@ -2491,10 +2600,12 @@
         },
         "punycode": {
           "version": "2.3.1",
+          "bundled": true,
           "dev": true
         },
         "react": {
           "version": "17.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
@@ -2503,6 +2614,7 @@
         },
         "react-devtools-core": {
           "version": "4.28.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "shell-quote": "^1.6.1",
@@ -2511,6 +2623,7 @@
         },
         "react-reconciler": {
           "version": "0.26.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
@@ -2520,6 +2633,7 @@
         },
         "redeyed": {
           "version": "2.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "esprima": "~4.0.0"
@@ -2527,10 +2641,12 @@
         },
         "resolve-from": {
           "version": "3.0.0",
+          "bundled": true,
           "dev": true
         },
         "restore-cursor": {
           "version": "3.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "onetime": "^5.1.0",
@@ -2539,6 +2655,7 @@
         },
         "rimraf": {
           "version": "3.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -2546,6 +2663,7 @@
         },
         "scheduler": {
           "version": "0.20.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
@@ -2554,18 +2672,22 @@
         },
         "semver": {
           "version": "6.3.1",
+          "bundled": true,
           "dev": true
         },
         "shell-quote": {
           "version": "1.8.1",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.7",
+          "bundled": true,
           "dev": true
         },
         "slice-ansi": {
           "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -2575,6 +2697,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.3.0",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "color-convert": "^2.0.1"
@@ -2582,6 +2705,7 @@
             },
             "color-convert": {
               "version": "2.0.1",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "color-name": "~1.1.4"
@@ -2589,12 +2713,14 @@
             },
             "color-name": {
               "version": "1.1.4",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "stack-utils": {
           "version": "2.0.6",
+          "bundled": true,
           "dev": true,
           "requires": {
             "escape-string-regexp": "^2.0.0"
@@ -2602,12 +2728,14 @@
           "dependencies": {
             "escape-string-regexp": {
               "version": "2.0.0",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "string-width": {
           "version": "4.2.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -2617,6 +2745,7 @@
         },
         "strip-ansi": {
           "version": "6.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
@@ -2624,6 +2753,7 @@
         },
         "supports-color": {
           "version": "5.5.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -2631,6 +2761,7 @@
         },
         "tap-parser": {
           "version": "11.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "events-to-array": "^1.0.1",
@@ -2640,6 +2771,7 @@
         },
         "tap-yaml": {
           "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "yaml": "^1.10.2"
@@ -2647,10 +2779,12 @@
         },
         "to-fast-properties": {
           "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "treport": {
           "version": "3.0.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@isaacs/import-jsx": "^4.0.1",
@@ -2665,6 +2799,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.3.0",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "color-convert": "^2.0.1"
@@ -2672,6 +2807,7 @@
             },
             "chalk": {
               "version": "3.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -2680,6 +2816,7 @@
             },
             "color-convert": {
               "version": "2.0.1",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "color-name": "~1.1.4"
@@ -2687,14 +2824,17 @@
             },
             "color-name": {
               "version": "1.1.4",
+              "bundled": true,
               "dev": true
             },
             "has-flag": {
               "version": "4.0.0",
+              "bundled": true,
               "dev": true
             },
             "supports-color": {
               "version": "7.2.0",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "has-flag": "^4.0.0"
@@ -2704,10 +2844,12 @@
         },
         "type-fest": {
           "version": "0.12.0",
+          "bundled": true,
           "dev": true
         },
         "unicode-length": {
           "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "punycode": "^2.0.0"
@@ -2715,6 +2857,7 @@
         },
         "update-browserslist-db": {
           "version": "1.0.13",
+          "bundled": true,
           "dev": true,
           "requires": {
             "escalade": "^3.1.1",
@@ -2723,6 +2866,7 @@
         },
         "widest-line": {
           "version": "3.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^4.0.0"
@@ -2730,6 +2874,7 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -2739,6 +2884,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.3.0",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "color-convert": "^2.0.1"
@@ -2746,6 +2892,7 @@
             },
             "color-convert": {
               "version": "2.0.1",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "color-name": "~1.1.4"
@@ -2753,28 +2900,35 @@
             },
             "color-name": {
               "version": "1.1.4",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "ws": {
           "version": "7.5.9",
-          "dev": true
+          "bundled": true,
+          "dev": true,
+          "requires": {}
         },
         "yallist": {
           "version": "3.1.1",
+          "bundled": true,
           "dev": true
         },
         "yaml": {
           "version": "1.10.2",
+          "bundled": true,
           "dev": true
         },
         "yoga-layout-prebuilt": {
           "version": "1.10.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@types/yoga-layout": "1.9.2"
@@ -2866,11 +3020,6 @@
       "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.1.2.tgz",
       "integrity": "sha512-vDPiDBC3hyP6O4JrJYMImW3nl3c03Tsj9fEXc7Qc/XKa1O7gf5ZtFfIR/E0dun9SnDHdwjna1Z2rSzYgqpxh/g==",
       "dev": true
-    },
-    "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tap": "^16.0.1"
   },
   "dependencies": {
-    "@sentry/node": "^6.0.0",
+    "@sentry/node": "^7.119.2",
     "pino-pretty": "^6.0.0",
     "pump": "^3.0.0",
     "readable-stream": "^3.6.0",

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -87,12 +87,12 @@ test("cli", (t) => {
         body += chunk.toString();
       });
       request.on("end", () => {
-        const data = JSON.parse(body);
-        const error = data.exception.values[0];
+        const data = body.split("\n").map((line) => JSON.parse(line));
+        const error = data[2].exception.values[0];
 
         t.equal(error.type, "Error");
         t.equal(error.value, "Oops");
-        t.strictSame(data.extra, {
+        t.strictSame(data[2].extra, {
           event: {
             event: "installation_repositories.added",
             id: "123",
@@ -166,8 +166,8 @@ sentryEventId: 123`
         body += chunk.toString();
       });
       request.on("end", () => {
-        const data = JSON.parse(body);
-        const error = data.exception.values[0];
+        const data = body.split("\n").map((line) => JSON.parse(line));
+        const error = data[2].exception.values[0];
 
         t.equal(error.type, "Error");
         t.equal(error.value, "Oh no!");

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,7 +23,7 @@ test("API", (t) => {
     t.end();
   });
 
-  t.test("Sentry integation enabled", (t) => {
+  t.test("Sentry integration enabled", (t) => {
     const transform = getTransformStream({
       sentryDsn: "http://username@example.com/1234",
     });
@@ -50,7 +50,7 @@ test("API", (t) => {
 
       Sentry.withScope(function (scope) {
         scope.addEventProcessor(function (event, hint) {
-          t.strictSame(event.user, { id: "456", username: undefined });
+          t.strictSame(event.user, { id: "456" });
         });
 
         log.fatal(event({}));


### PR DESCRIPTION
This PR upgrades just `@sentry/node` to v7 to help clear downstream audit failures related to https://github.com/advisories/GHSA-pxg6-pf52-xh8x. I'm only jumping to `@sentry/node` v7 as it's still maintained, and supports down to Node.js v8 so this doesn't need to be a breaking change for `@probot/pino`.

cc @gr2m