### PR TITLE
fix: report stack trace to Sentry

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ function stringifyLogLevel(data) {
 
 function toSentryError(data) {
   const error = new Error(data.msg);
-  error.name = data.type;
-  error.stack = data.stack;
+  error.name = data.type || data.err?.type;
+  error.stack = data.stack || data.err?.stack;
   return error;
 }


### PR DESCRIPTION
I don't know if this is just the case for me, or for everyone else, but with default log config on Probot 13.4.5, `.type` and `.stack` properties are not directly on the log data object, but rather in an object under an `.err` property.

The error stack is therefore not reported to Sentry. This patch fix this.