### PR TITLE
ci(release): remove NPM_TOKEN, use OIDC for npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
           cache: npm
@@ -28,4 +28,3 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.PROBOTBOT_NPM_TOKEN }}


### PR DESCRIPTION
Removes `NPM_TOKEN` — `id-token: write` permission already present, so OIDC trusted publishing handles authentication.

See https://github.com/gr2m/semantic-release-plugin-update-version-in-files/pull/62 for reference.